### PR TITLE
fix errors in keymappings

### DIFF
--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -1,4 +1,5 @@
 local utils = require('utils')
+local wk = require("which-key")
 -- ToggleTerm Key Mappings
 utils.map('i', [[<C-\>]], '<cmd>exe v:count1 . "ToggleTerm size=80 direction=vertical"<CR>')
 utils.map('n', [[<C-\>]], '<cmd>exe v:count1 . "ToggleTerm size=80 direction=vertical"<CR>')
@@ -34,7 +35,7 @@ wk.register({
     -- define key mappings for telescope
     f = {
         name = "telescope",
-        f = { function require('telescope.builtin').fild_files end },
+        f = { function() require('telescope.builtin').find_files() end },
     },
 }, { prefix = "<leader>" })
 
@@ -45,7 +46,6 @@ vim.keymap.set('n', '<leader>hp', require('harpoon.ui').nav_prev)
 utils.map('n', [[<leader>hm]], ':Telescope harpoon marks<CR>')
 
 -- Harpoon Which-key mappings
-local wk = require("which-key")
 wk.register({
     -- The first key you are pressing
     h = {


### PR DESCRIPTION
A couple of errors occur when starting neovim:

```text
Error detected while processing /root/.config/nvim/init.lua:
E5113: Error while calling lua chunk: vim/_init_packages.lua:0: /root/.config/nvim/lua/keymappings.lua:37
: '(' expected near 'require'
stack traceback:
        [C]: in function 'error'
        vim/_init_packages.lua: in function <vim/_init_packages.lua:0>
        [C]: in function 'require'
        /root/.config/nvim/init.lua:24: in main chunk
```

and:

```text
Error detected while processing /root/.config/nvim/init.lua:
E5113: Error while calling lua chunk: /root/.config/nvim/lua/keymappings.lua:33: attempt to index global
'wk' (a nil value)
stack traceback:
        /root/.config/nvim/lua/keymappings.lua:33: in main chunk
        [C]: in function 'require'
        /root/.config/nvim/init.lua:24: in main chunk
```

I also noticed that there was `fild_files` not `find_files`.

This PR addresses these issues.

Thanks for your weekly neovim plugin series on YT!
